### PR TITLE
moving schemas to be cached in the data cache

### DIFF
--- a/api/schema/XmlSchemaCache.inc
+++ b/api/schema/XmlSchemaCache.inc
@@ -26,7 +26,7 @@ class XmlSchemaCache {
    * The Drupal cache ID where the mappings of urls to actual files are stored.
    */
   const ID = 'xml-schema-table';
-  const TYPE = 'cache';
+  const TYPE = 'data';
 
   const LOCATION = 'public://schemas';
 


### PR DESCRIPTION
The cache cache is not a cache.  The data bin seems appropriate.