### PR TITLE
Port ISLANDORA-1402

### DIFF
--- a/builder/XMLFormDatabase.inc
+++ b/builder/XMLFormDatabase.inc
@@ -164,6 +164,7 @@ class XMLFormDatabase {
       $definition = XMLFormDefinition::upgradeToLatestVersion($definition);
       $fields = [];
       $fields['name'] = $form_name;
+      $fields['machine_name'] = static::getMachineName($form_name);
       $fields['form'] = $definition->saveXML();
       return \Drupal::database()->insert(static::TABLE)->fields($fields)->execute() !== FALSE;
     }
@@ -245,6 +246,36 @@ class XMLFormDatabase {
       }
     }
     return FALSE;
+  }
+
+  /**
+   * Returns a machine name that can by used in URLs.
+   *
+   * @param string
+   *   A form name that might have URL-breaking characters.
+   *
+   * @return string
+   *   The form name that doesn't have characters that will break URLs.
+   */
+  public static function getMachineName($form_name) {
+    $machine_name = str_replace('/', 'slash', $form_name);
+    return $machine_name;
+  }
+
+  /**
+   * Returns the form name corresponding to the given machine name.
+   *
+   * @param string
+   *   The machine name for the desired form.
+   *
+   * @return string
+   *   The form name for the desired form.
+   */
+  public static function getFormName($machine_name) {
+    $query = db_query('SELECT name FROM {xml_forms} WHERE machine_name = :machine_name', [':machine_name' => $machine_name]);
+    $row = $query->fetchAssoc();
+    $form_name = $row['name'];
+    return $form_name;
   }
 
 }

--- a/builder/XMLFormDatabase.inc
+++ b/builder/XMLFormDatabase.inc
@@ -278,4 +278,39 @@ class XMLFormDatabase {
     return $form_name;
   }
 
+  /**
+   * Returns true if there is a machine name for the given form form name.
+   * Helps with backward compatibility before an update hook is written.
+   *
+   * @param string
+   *   The machine name.
+   *
+   * @return bool
+   *   True if there is a machine name for the given form name.
+   */
+  public static function machineNameExists($machine_name) {
+    $query = db_query('SELECT name FROM {xml_forms} WHERE machine_name = :machine_name', [':machine_name' => $machine_name]);
+    $row = $query->fetchAssoc();
+    if ($row === FALSE) {
+      return FALSE;
+    }
+    else {
+      return TRUE;
+    }
+  }
+
+  /**
+   * Creates and adds a machine name to the database.
+   *
+   * @param string
+   *   Form name.
+   */
+  public static function updateMachineName($form_name) {
+    $machine_name = getMachineName($form_name);
+    $connection = \Drupal::service('database');
+    $connection->update('xml_forms')
+      ->fields(['machine_name' => $machine_name])
+      ->condition('name', $form_name, '==');
+  }
+
 }

--- a/builder/XMLFormDatabase.inc
+++ b/builder/XMLFormDatabase.inc
@@ -289,6 +289,11 @@ class XMLFormDatabase {
    *   True if there is a machine name for the given form name.
    */
   public static function machineNameExists($machine_name) {
+    // XXX: This would be unnecessary if there was an update hook.
+    $connection = \Drupal::service('database');
+    if (!$connection->schema()->fieldExists(self::TABLE, 'machine_name')) {
+      return FALSE;
+    }
     $query = db_query('SELECT name FROM {xml_forms} WHERE machine_name = :machine_name', [':machine_name' => $machine_name]);
     $row = $query->fetchAssoc();
     if ($row === FALSE) {
@@ -300,13 +305,24 @@ class XMLFormDatabase {
   }
 
   /**
-   * Creates and adds a machine name to the database.
+   * Creates and adds a machine name to the database after making sure the
+   * field exists.
    *
    * @param string
    *   Form name.
    */
   public static function updateMachineName($form_name) {
-    $machine_name = getMachineName($form_name);
+    // XXX: This is essentially what should be in an update hook.
+    $connection = \Drupal::service('database');
+    if (!$connection->schema()->fieldExists(self::TABLE, 'machine_name')) {
+      $machine_name_col = [
+        'description' => 'The form name that will not break the URL.',
+        'type' => 'varchar',
+        'length' => 128,
+      ];
+      $connection->schema()->addField(self::TABLE, 'machine_name', $machine_name_col);
+    }
+    $machine_name = static::getMachineName($form_name);
     $connection = \Drupal::service('database');
     $connection->update('xml_forms')
       ->fields(['machine_name' => $machine_name])

--- a/builder/XMLFormDatabase.inc
+++ b/builder/XMLFormDatabase.inc
@@ -291,9 +291,6 @@ class XMLFormDatabase {
   public static function machineNameExists($machine_name) {
     // XXX: This would be unnecessary if there was an update hook.
     $connection = \Drupal::service('database');
-    if (!$connection->schema()->fieldExists(self::TABLE, 'machine_name')) {
-      return FALSE;
-    }
     $query = db_query('SELECT name FROM {xml_forms} WHERE machine_name = :machine_name', [':machine_name' => $machine_name]);
     $row = $query->fetchAssoc();
     if ($row === FALSE) {
@@ -320,7 +317,6 @@ class XMLFormDatabase {
         'type' => 'varchar',
         'length' => 128,
       ];
-      $connection->schema()->addField(self::TABLE, 'machine_name', $machine_name_col);
     }
     $machine_name = static::getMachineName($form_name);
     $connection = \Drupal::service('database');

--- a/builder/XMLFormDatabase.inc
+++ b/builder/XMLFormDatabase.inc
@@ -326,7 +326,8 @@ class XMLFormDatabase {
     $connection = \Drupal::service('database');
     $connection->update('xml_forms')
       ->fields(['machine_name' => $machine_name])
-      ->condition('name', $form_name, '==');
+      ->condition('name', $form_name)
+      ->execute();
   }
 
 }

--- a/builder/XMLFormDatabase.inc
+++ b/builder/XMLFormDatabase.inc
@@ -311,15 +311,7 @@ class XMLFormDatabase {
   public static function updateMachineName($form_name) {
     // XXX: This is essentially what should be in an update hook.
     $connection = \Drupal::service('database');
-    if (!$connection->schema()->fieldExists(self::TABLE, 'machine_name')) {
-      $machine_name_col = [
-        'description' => 'The form name that will not break the URL.',
-        'type' => 'varchar',
-        'length' => 128,
-      ];
-    }
     $machine_name = static::getMachineName($form_name);
-    $connection = \Drupal::service('database');
     $connection->update('xml_forms')
       ->fields(['machine_name' => $machine_name])
       ->condition('name', $form_name)

--- a/builder/XMLFormDatabase.inc
+++ b/builder/XMLFormDatabase.inc
@@ -251,7 +251,7 @@ class XMLFormDatabase {
   /**
    * Returns a machine name that can by used in URLs.
    *
-   * @param string
+   * @param string $form_name
    *   A form name that might have URL-breaking characters.
    *
    * @return string
@@ -265,7 +265,7 @@ class XMLFormDatabase {
   /**
    * Returns the form name corresponding to the given machine name.
    *
-   * @param string
+   * @param string $machine_name
    *   The machine name for the desired form.
    *
    * @return string
@@ -280,9 +280,10 @@ class XMLFormDatabase {
 
   /**
    * Returns true if there is a machine name for the given form form name.
+   *
    * Helps with backward compatibility before an update hook is written.
    *
-   * @param string
+   * @param string $machine_name
    *   The machine name.
    *
    * @return bool
@@ -290,7 +291,6 @@ class XMLFormDatabase {
    */
   public static function machineNameExists($machine_name) {
     // XXX: This would be unnecessary if there was an update hook.
-    $connection = \Drupal::service('database');
     $query = db_query('SELECT name FROM {xml_forms} WHERE machine_name = :machine_name', [':machine_name' => $machine_name]);
     $row = $query->fetchAssoc();
     if ($row === FALSE) {
@@ -302,11 +302,10 @@ class XMLFormDatabase {
   }
 
   /**
-   * Creates and adds a machine name to the database after making sure the
-   * field exists.
+   * Creates and adds a machine name to the database.
    *
-   * @param string
-   *   Form name.
+   * @param string $form_name
+   *   The form name entered by the user when the form was created.
    */
   public static function updateMachineName($form_name) {
     // XXX: This is essentially what should be in an update hook.

--- a/builder/XMLFormRepository.inc
+++ b/builder/XMLFormRepository.inc
@@ -224,7 +224,7 @@ class XMLFormRepository extends XMLFormDatabase {
   /**
    * Returns the form name for the given machine name.
    *
-   * @param string
+   * @param string $machine_name
    *   The machine name of the desired form.
    *
    * @return string

--- a/builder/XMLFormRepository.inc
+++ b/builder/XMLFormRepository.inc
@@ -35,7 +35,7 @@ class XMLFormRepository extends XMLFormDatabase {
 
     // Get machine names for URLs.
     foreach ($hooks as $form_name => $info) {
-      $hooks[$form_name] += ['machine_name' => parent::getMachineName($form_name)];
+      $hooks[$form_name] += ['machine_name' => static::getMachineName($form_name)];
     }
 
     return $hooks;
@@ -140,7 +140,7 @@ class XMLFormRepository extends XMLFormDatabase {
 
     $db_names = parent::getNames();
     foreach ($db_names as $key => $array) {
-      $db_names[$key] += ['machine_name' => parent::getMachineName($array['name'])];
+      $db_names[$key] += ['machine_name' => static::getMachineName($array['name'])];
     }
     usort($hook_names, ['XMLFormRepository', 'comparisonFunction']);
 

--- a/builder/XMLFormRepository.inc
+++ b/builder/XMLFormRepository.inc
@@ -32,6 +32,12 @@ class XMLFormRepository extends XMLFormDatabase {
     // @todo Remove (deprecated) invokation if
     // "islandora_xml_form_builder_forms".
     $hooks += \Drupal::moduleHandler()->invokeAll('islandora_xml_form_builder_forms');
+
+    // Get machine names for URLs.
+    foreach ($hooks as $form_name => $info) {
+      $hooks[$form_name] += ['machine_name' => parent::getMachineName($form_name)];
+    }
+
     return $hooks;
   }
 
@@ -124,11 +130,18 @@ class XMLFormRepository extends XMLFormDatabase {
     $hook = static::getFormsFromHook();
     $hook_names = [];
     foreach ($hook as $key => $array) {
-      $hook_names[] = ['name' => $key, 'indb' => FALSE];
+      $hook_names[] = [
+        'name' => $key,
+        'indb' => FALSE,
+        'machine_name' => $array['machine_name'],
+      ];
     }
     usort($hook_names, ['XMLFormRepository', 'comparisonFunction']);
 
     $db_names = parent::getNames();
+    foreach ($db_names as $key => $array) {
+      $db_names[$key] += ['machine_name' => parent::getMachineName($array['name'])];
+    }
     usort($hook_names, ['XMLFormRepository', 'comparisonFunction']);
 
     $names = array_merge($hook_names, $db_names);
@@ -206,6 +219,28 @@ class XMLFormRepository extends XMLFormDatabase {
       return static::create($form_name_dest, $definition);
     }
     return FALSE;
+  }
+
+  /**
+   * Returns the form name for the given machine name.
+   *
+   * @param string
+   *   The machine name of the desired form.
+   *
+   * @return string
+   *   The form name of the desired form.
+   */
+  public static function getFormName($machine_name) {
+    $form_name = parent::getFormName($machine_name);
+    if (empty($form_name)) {
+      $hooks = static::getFormsFromHook();
+      foreach ($hooks as $name => $form_info) {
+        if ($form_info['machine_name'] == $machine_name) {
+          return $name;
+        }
+      }
+    }
+    return $form_name;
   }
 
 }

--- a/builder/src/Controller/DefaultController.php
+++ b/builder/src/Controller/DefaultController.php
@@ -353,8 +353,6 @@ class DefaultController extends ControllerBase {
     module_load_include('inc', 'xml_form_builder', 'includes/associations');
     module_load_include('inc', 'xml_form_builder', 'XMLFormRepository');
 
-    $form_name = \XMLFormRepository::getFormName($form_machine_name);
-
     $association = xml_form_builder_get_association($id);
     if (!isset($association)) {
       drupal_set_message($this->t('Specified association does not exist.'), 'error');

--- a/builder/src/Controller/DefaultController.php
+++ b/builder/src/Controller/DefaultController.php
@@ -72,6 +72,11 @@ class DefaultController extends ControllerBase {
     foreach ($names as $form_info) {
       $name = $form_info['name'];
       $machine_name = $form_info['machine_name'];
+      // XXX: For backwards compatability that should be handled in an update
+      // hook at some point.
+      if ($form_info['indb'] && !(\XMLFormDatabase::machineNameExists($machine_name))) {
+        updateMachineName($name);
+      }
       if ($form_info['indb']) {
         $type = $this->t('Custom');
         $edit = Link::createFromRoute(
@@ -157,9 +162,15 @@ class DefaultController extends ControllerBase {
 
     // Returns a link to the edit associations form for form $form_name.
     $create_form_association_link = function ($form_name) {
+      // XXX: For backward compatibility that should be handled by an update
+      // hook at some point.
+      $machine_name = \XMLFormDatabase::getMachineName($form_name);
+      if (\XMLFormDatabase::exists($form_name) && !\XMLFormDatabase::machineNameExists($machine_name)) {
+        \XMLFormDatabase::updateMachineName($form_name);
+      }
       return [
         Link::createFromRoute($form_name, 'xml_form_builder.associations_form', [
-          'form_machine_name' => \XMLFormDatabase::getMachineName($form_name),
+          'form_machine_name' => $machine_name,
         ]),
       ];
     };

--- a/builder/src/Controller/DefaultController.php
+++ b/builder/src/Controller/DefaultController.php
@@ -75,7 +75,7 @@ class DefaultController extends ControllerBase {
       // XXX: For backwards compatability that should be handled in an update
       // hook at some point.
       if ($form_info['indb'] && !(\XMLFormDatabase::machineNameExists($machine_name))) {
-        updateMachineName($name);
+        \XMLFormDatabase::updateMachineName($name);
       }
       if ($form_info['indb']) {
         $type = $this->t('Custom');

--- a/builder/src/Controller/DefaultController.php
+++ b/builder/src/Controller/DefaultController.php
@@ -196,7 +196,7 @@ class DefaultController extends ControllerBase {
   /**
    * Downloads the XML Form Definition to the clients computer..
    *
-   * @param string $form_name
+   * @param string $form_machine_name
    *   The name of the form to download.
    */
   public function export($form_machine_name) {
@@ -251,7 +251,7 @@ class DefaultController extends ControllerBase {
    * Transforms the submited JSON into a Form Definition which is then stored in
    * the database as an XML Form Definition.
    *
-   * @param string $form_name
+   * @param string $form_machine_name
    *   The name of the form to update.
    *
    * @throws Exception
@@ -283,7 +283,7 @@ class DefaultController extends ControllerBase {
    * Either by deleting it from the database, or marking it disabled if its
    * provided by a hook.
    *
-   * @param string $form_name
+   * @param string $form_machine_name
    *   The name of the form for which the associations are being adjusted.
    *   (used to redirect).
    * @param string|int $id
@@ -341,7 +341,7 @@ class DefaultController extends ControllerBase {
   /**
    * Enable a default association identified by $id.
    *
-   * @param string $form_name
+   * @param string $form_machine_name
    *   The name of the form for which the associations are being adjusted.
    *   (used to redirect).
    * @param string $id

--- a/builder/src/Form/AssociationsForm.php
+++ b/builder/src/Form/AssociationsForm.php
@@ -27,9 +27,12 @@ class AssociationsForm extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, $form_name = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, $form_machine_name = NULL) {
     $form_state->loadInclude('xml_form_builder', 'inc', 'includes/associations.form');
     $form_state->loadInclude('xml_form_builder', 'inc', 'includes/associations');
+    $form_state->loadInclude('xml_form_builder', 'inc', 'XMLFormRepository');
+
+    $form_name = \XMLFormRepository::getFormName($form_machine_name);
 
     $associations = xml_form_builder_get_associations([$form_name], [], [], FALSE);
     $create_table_rows = function ($association) {
@@ -77,14 +80,14 @@ class AssociationsForm extends FormBase {
       $operations = NULL;
       if ($association['type'] == 'hook') {
         if ($association['enabled']) {
-          $operations = Link::createFromRoute($this->t("Disable"), 'xml_form_builder.disable_association', ['form_name' => $association['form_name'], 'id' => $association['id']]);
+          $operations = Link::createFromRoute($this->t("Disable"), 'xml_form_builder.disable_association', ['form_machine_name' => $form_machine_name, 'id' => $association['id']]);
         }
         else {
-          $operations = Link::createFromRoute($this->t("Enable"), 'xml_form_builder.enable_association', ['form_name' => $association['form_name'], 'id' => $association['id']]);
+          $operations = Link::createFromRoute($this->t("Enable"), 'xml_form_builder.enable_association', ['form_machine_name' => $form_machine_name, 'id' => $association['id']]);
         }
       }
       else {
-        $operations = Link::createFromRoute($this->t("Delete"), 'xml_form_builder.disable_association', ['form_name' => $association['form_name'], 'id' => $association['id']]);
+        $operations = Link::createFromRoute($this->t("Delete"), 'xml_form_builder.disable_association', ['form_machine_name' => $form_machine_name, 'id' => $association['id']]);
       }
       $row[] = $operations;
       $rows[] = $row;

--- a/builder/src/Form/Copy.php
+++ b/builder/src/Form/Copy.php
@@ -21,10 +21,11 @@ class Copy extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, $form_name = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, $form_machine_name = NULL) {
     $form_state->loadInclude('xml_form_builder', 'inc', 'Copy');
     $form_state->loadInclude('xml_form_api', 'inc', 'XMLFormDefinition');
     $form_state->loadInclude('xml_form_builder', 'inc', 'XMLFormRepository');
+    $form_name = \XMLFormRepository::getFormName($form_machine_name);
     if (isset($_POST['cancel'])) {
       return $this->redirect('xml_form_builder.main');
     }
@@ -66,6 +67,7 @@ class Copy extends FormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $form_state->loadInclude('xml_form_api', 'inc', 'XMLFormDefinition');
     $form_state->loadInclude('xml_form_builder', 'inc', 'XMLFormRepository');
+    $form_state->loadInclude('xml_form_builder', 'inc', 'XMLFormDatabase');
     if ($form_state->getTriggeringElement()['#name'] == 'copy') {
       $original = $form_state->getValue(['original']);
       $form_name = $form_state->getValue(['form_name']);
@@ -73,7 +75,7 @@ class Copy extends FormBase {
         drupal_set_message($this->t('Successfully copied form "%name".', [
           '%name' => $form_name,
         ]));
-        $form_state->setRedirect('xml_form_builder.edit', ['form_name' => $form_name]);
+        $form_state->setRedirect('xml_form_builder.edit', ['form_machine_name' => \XMLFormDatabase::getMachineName($form_name)]);
         return;
       }
       drupal_set_message($this->t('Failed to copy form "%name".', [

--- a/builder/src/Form/Create.php
+++ b/builder/src/Form/Create.php
@@ -112,6 +112,7 @@ class Create extends FormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $form_state->loadInclude('xml_form_api', 'inc', 'XMLFormDefinition');
     $form_state->loadInclude('xml_form_builder', 'inc', 'XMLFormRepository');
+    $form_state->loadInclude('xml_form_builder', 'inc', 'XMLFormDatabase');
     $form_name = $form_state->getValue(['form_name']);
     if ($form_state->getTriggeringElement()['#name'] == 'create') {
       $definition = xml_form_builder_create_get_uploaded_file();
@@ -120,7 +121,7 @@ class Create extends FormBase {
         drupal_set_message($this->t('Successfully created form "%name".', [
           '%name' => $form_name,
         ]));
-        $form_state->setRedirect('xml_form_builder.edit', ['form_name' => $form_name]);
+        $form_state->setRedirect('xml_form_builder.edit', ['form_machine_name' => \XMLFormDatabase::getMachineName($form_name)]);
         return;
       }
       else {

--- a/builder/src/Form/Delete.php
+++ b/builder/src/Form/Delete.php
@@ -21,8 +21,10 @@ class Delete extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, $form_name = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, $form_machine_name = NULL) {
     $form_state->loadInclude('xml_form_builder', 'inc', 'XMLFormDatabase');
+    $form_state->loadInclude('xml_form_builder', 'inc', 'XMLFormRepository');
+    $form_name = \XMLFormRepository::getFormName($form_machine_name);
     if (!\XMLFormDatabase::exists($form_name)) {
       drupal_set_message($this->t('Form "%name" does not exist.', [
         '%name' => $form_name,

--- a/builder/src/Form/Preview.php
+++ b/builder/src/Form/Preview.php
@@ -24,7 +24,9 @@ class Preview extends FormBase {
   /**
    * {@inheritdoc}
    */
-  public function buildForm(array $form, FormStateInterface $form_state, $form_name = NULL) {
+  public function buildForm(array $form, FormStateInterface $form_state, $form_machine_name = NULL) {
+    $form_state->loadInclude('xml_form_builder', 'inc', 'XMLFormRepository');
+    $form_name = \XMLFormRepository::getFormName($form_machine_name);
     $form = xml_form_builder_get_form($form, $form_state, $form_name);
     $form['submit'] = [
       '#type' => 'submit',

--- a/builder/xml_form_builder.install
+++ b/builder/xml_form_builder.install
@@ -32,7 +32,6 @@ function xml_form_builder_schema() {
         'description' => 'The form name that will not break the URL.',
         'type' => 'varchar',
         'length' => 128,
-        'not null' => TRUE,
       ],
     ],
     'unique keys' => ['name' => ['name']],

--- a/builder/xml_form_builder.install
+++ b/builder/xml_form_builder.install
@@ -28,6 +28,12 @@ function xml_form_builder_schema() {
         'size' => 'medium',
         'not null' => TRUE,
       ],
+      'machine_name' => [
+        'description' => 'The form name that will not break the URL.',
+        'type' => 'varchar',
+        'length' => 128,
+        'not null' => TRUE,
+      ],
     ],
     'unique keys' => ['name' => ['name']],
     'primary key' => ['id'],

--- a/builder/xml_form_builder.routing.yml
+++ b/builder/xml_form_builder.routing.yml
@@ -57,63 +57,63 @@ xml_form_builder.create_import:
   requirements:
     _permission: 'Create XML Forms'
 xml_form_builder.preview:
-  path: '/admin/config/islandora/xmlform/forms/{form_name}/view'
+  path: '/admin/config/islandora/xmlform/forms/{form_machine_name}/view'
   defaults:
     _title: 'Preview Form'
     _form: \Drupal\xml_form_builder\Form\Preview
   requirements:
     _permission: 'List XML Forms'
 xml_form_builder.export:
-  path: '/admin/config/islandora/xmlform/forms/{form_name}/export'
+  path: '/admin/config/islandora/xmlform/forms/{form_machine_name}/export'
   defaults:
     _title: 'Export Form'
     _controller: '\Drupal\xml_form_builder\Controller\DefaultController::export'
   requirements:
     _permission: 'List XML Forms'
 xml_form_builder.copy:
-  path: '/admin/config/islandora/xmlform/forms/{form_name}/copy'
+  path: '/admin/config/islandora/xmlform/forms/{form_machine_name}/copy'
   defaults:
     _title: 'Copy Form'
     _form: \Drupal\xml_form_builder\Form\Copy
   requirements:
     _permission: 'Create XML Forms'
 xml_form_builder.edit:
-  path: '/admin/config/islandora/xmlform/forms/{form_name}/edit'
+  path: '/admin/config/islandora/xmlform/forms/{form_machine_name}/edit'
   defaults:
     _title: 'Edit Form'
     _controller: '\Drupal\xml_form_builder\Controller\DefaultController::edit'
   requirements:
     _permission: 'Edit XML Forms'
 xml_form_builder.edit_save:
-  path: '/admin/config/islandora/xmlform/forms/{form_name}/edit/save'
+  path: '/admin/config/islandora/xmlform/forms/{form_machine_name}/edit/save'
   defaults:
     _title: 'Edit Form'
     _controller: '\Drupal\xml_form_builder\Controller\DefaultController::editSave'
   requirements:
     _permission: 'Edit XML Forms'
 xml_form_builder.delete:
-  path: '/admin/config/islandora/xmlform/forms/{form_name}/delete'
+  path: '/admin/config/islandora/xmlform/forms/{form_machine_name}/delete'
   defaults:
     _title: 'Delete Form'
     _form: \Drupal\xml_form_builder\Form\Delete
   requirements:
     _permission: 'Delete XML Forms'
 xml_form_builder.associations_form:
-  path: '/admin/config/islandora/xmlform/forms/{form_name}/associations'
+  path: '/admin/config/islandora/xmlform/forms/{form_machine_name}/associations'
   defaults:
     _title: 'Associate Form'
     _form: \Drupal\xml_form_builder\Form\AssociationsForm
   requirements:
     _permission: 'Associate XML Forms'
 xml_form_builder.disable_association:
-  path: '/admin/config/islandora/xmlform/forms/{form_name}/disassociate/{id}'
+  path: '/admin/config/islandora/xmlform/forms/{form_machine_name}/disassociate/{id}'
   defaults:
     _title: 'Disable Form Association'
     _controller: '\Drupal\xml_form_builder\Controller\DefaultController::disableAssociation'
   requirements:
     _permission: 'Associate XML Forms'
 xml_form_builder.enable_association:
-  path: '/admin/config/islandora/xmlform/forms/{form_name}/associate/{id}'
+  path: '/admin/config/islandora/xmlform/forms/{form_machine_name}/associate/{id}'
   defaults:
     _title: 'Enable Form Association'
     _controller: '\Drupal\xml_form_builder\Controller\DefaultController::enableAssociation'


### PR DESCRIPTION
* Other Relevant Links (Google Groups discussion, related pull requests, etc.)
[Islandora pull](https://github.com/Islandora/islandora_xml_forms/pull/257)
[Islandora ticket](https://jira.duraspace.org/browse/ISLANDORA-1402)

# What does this Pull Request do?

URLs break when forms have slashes in their names. The D7 fix doesn't work in D8 because of how routing works, so this fix uses machine names that just replace slashes with 'slash'.

# What's new?
Added little methods to get the form name given the machine name, or the machine name given the form name.

# How should this be tested?
See the Islandora pull listed above.

To test for backward compatibility:

- Manually add a record to the xml_forms db without a machine name
- Drush cr
- Go to admin/config/islandora/xmlform/forms and it should display fine with all functionality working, and the db should now have a machine name for the added form.
