### PR TITLE
prevent validation on copy cancel

### DIFF
--- a/builder/src/Form/Copy.php
+++ b/builder/src/Form/Copy.php
@@ -56,6 +56,7 @@ class Copy extends FormBase {
         '#type' => 'submit',
         '#value' => $this->t('Cancel'),
         '#name' => 'cancel',
+        '#limit_validation_errors' => [],
       ],
     ];
   }


### PR DESCRIPTION
Canceling the form copy form would result in validation errors, but it should always pass.