### PR TITLE
Add missing type reference.

### DIFF
--- a/api/ActionInterface.inc
+++ b/api/ActionInterface.inc
@@ -5,6 +5,8 @@
  * Interface for supporting actions.
  */
 
+use Drupal\objective_forms\FormElement;
+
 /**
  * Interface that all actions support.
  *


### PR DESCRIPTION
Otherwise, can go boom with:

```
PHP Fatal error:  Declaration of Create::execute(XMLDocument $document, Drupal\objective_forms\FormElement $element, $value = NULL) must be compatible with ActionInterface::execute(XMLDocument $document, FormElement $element, $value = NULL) in /opt/www/drupal/modules/contrib/xml_forms/api/Create.inc on line 25
```