### PR TITLE
Update php version for D8

### DIFF
--- a/builder/xml_form_builder.info.yml
+++ b/builder/xml_form_builder.info.yml
@@ -4,5 +4,5 @@ package: 'Islandora Tools'
 dependencies:
   - :xml_form_api
 core: 8.x
-php: '5.5.9'
+php: '7.2'
 type: module

--- a/xml_forms.info.yml
+++ b/xml_forms.info.yml
@@ -6,5 +6,5 @@ dependencies:
   - :xml_form_elements
 package: 'Islandora Tools'
 core: 8.x
-php: '5.5.9'
+php: '7.2'
 type: module


### PR DESCRIPTION
php 5 support is being dropped:
[Drupal docs](https://www.drupal.org/docs/8/system-requirements/php-requirements)