### PR TITLE
php version updates

### DIFF
--- a/api/xml_form_api.info.yml
+++ b/api/xml_form_api.info.yml
@@ -6,3 +6,4 @@ dependencies:
   - :xml_schema_api
 core: 8.x
 type: module
+php: '7.2'

--- a/elements/xml_form_elements.info.yml
+++ b/elements/xml_form_elements.info.yml
@@ -4,5 +4,5 @@ package: 'Islandora Dependencies'
 dependencies:
   - :xml_form_api
 core: 8.x
-php: '5.5.9'
+php: '7.2'
 type: module


### PR DESCRIPTION
php 5 support is being dropped:
[Drupal docs](https://www.drupal.org/docs/8/system-requirements/php-requirements)